### PR TITLE
SOLVERTIC solve : 유사 칸토어 비트열

### DIFF
--- a/tkdlqh2/20230310-tkdlqh2.md
+++ b/tkdlqh2/20230310-tkdlqh2.md
@@ -1,0 +1,53 @@
+# 솔루션
+
+## 통과한 코드
+
+```java
+class Solution {
+	public int solution(int n, long l, long r) {
+
+		long lNum = getNumberOfOne(n,l-1);
+		long rNum = getNumberOfOne(n,r);
+
+		return (int) (rNum-lNum);
+	}
+
+	// 숫자 l 에 오기까지의 1의 갯수를 셉니다.
+	long getNumberOfOne(int n, long l){
+		int[] lArr= new int[n+1];
+
+		//숫자를 5진법으로 나타냅니다.
+		for (int i = 0; i < n+1; i++) {
+			lArr[n-i] = (int) (l%5);
+			l /= 5;
+		}
+
+		//5진법의 자릿수에 따른 1의 개수를 나타냅니다.
+		long[] arr = {0l,1l,2l,2l,3l};
+
+
+		int answer= 0;
+		for (int i = 0; i < n+1; i++) {
+			answer *= 4;
+			answer += arr[lArr[i]];
+			//세번째 0이 있는 블록은 확장해도 계속 0 이기 때문에
+			// 나머지가 2라면 기존 숫자들의 자릿수만 높여줍니다. 
+			if(lArr[i] == 2){
+				answer *= Math.pow(4,n-i);
+				break;
+			}
+		}
+
+		return answer;
+	}
+}
+```
+
+## 풀이 해설
+어떤 구간의 1의 갯수를 구하는 문제를 "처음부터 각 구간의 끝까지의 1의 갯수" 를 각각 구해서 높은 구간에서 낮은 구간을 빼는 방법으로 구했습니다.
+낮은 구간에서 1을 빼는 이유는 구하는 구간이 폐구간이기 때문에 그 숫자 전까지의 모든 1의 갯수를 구해서 빼야 말이 맞습니다.
+각 단계를 넘어갈 때 4를 곱하는 이유와 3 51 75 를 하면 0이 나와야 되는 이유를 생각하면 풀 수 있을 것 같습니다.
+
+## 아쉬운 점
+뭔가 풀이를 말로 설명하기 어렵네요.
+저 나머지가 2인 경우를 생각하기가 어려워서 겁나 헤매다 Test case 몇개 질문에서 보고 구했습니다.


### PR DESCRIPTION
# 솔루션

## 통과한 코드

```java
class Solution {
	public int solution(int n, long l, long r) {

		long lNum = getNumberOfOne(n,l-1);
		long rNum = getNumberOfOne(n,r);

		return (int) (rNum-lNum);
	}

	// 숫자 l 에 오기까지의 1의 갯수를 셉니다.
	long getNumberOfOne(int n, long l){
		int[] lArr= new int[n+1];

		//숫자를 5진법으로 나타냅니다.
		for (int i = 0; i < n+1; i++) {
			lArr[n-i] = (int) (l%5);
			l /= 5;
		}

		//5진법의 자릿수에 따른 1의 개수를 나타냅니다.
		long[] arr = {0l,1l,2l,2l,3l};


		int answer= 0;
		for (int i = 0; i < n+1; i++) {
			answer *= 4;
			answer += arr[lArr[i]];
			//세번째 0이 있는 블록은 확장해도 계속 0 이기 때문에
			// 나머지가 2라면 기존 숫자들의 자릿수만 높여줍니다. 
			if(lArr[i] == 2){
				answer *= Math.pow(4,n-i);
				break;
			}
		}

		return answer;
	}
}
```

## 풀이 해설
어떤 구간의 1의 갯수를 구하는 문제를 "처음부터 각 구간의 끝까지의 1의 갯수" 를 각각 구해서 높은 구간에서 낮은 구간을 빼는 방법으로 구했습니다.
낮은 구간에서 1을 빼는 이유는 구하는 구간이 폐구간이기 때문에 그 숫자 전까지의 모든 1의 갯수를 구해서 빼야 말이 맞습니다.
각 단계를 넘어갈 때 4를 곱하는 이유와, 3 51 75 를 하면 0이 나와야 되는 이유를 생각하면 풀 수 있을 것 같습니다.

## 아쉬운 점
뭔가 풀이를 말로 설명하기 어렵네요.
저 나머지가 2인 경우를 생각하기가 어려워서 겁나 헤매다 Test case 몇개 질문에서 보고 구했습니다.